### PR TITLE
INT-1446 Introduce support of multiple Counties for Person Search

### DIFF
--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -92,8 +92,8 @@
                       }
                     },
                     {
-                      "match": {
-                        "client_county.id": "{{_user.metadata.county_id}}"
+                      "term": {
+                        "client_counties.id": "{{_user.metadata.county_id}}"
                       }
                     }
                   ]
@@ -128,8 +128,8 @@
                       }
                     },
                     {
-                      "match": {
-                        "client_county.id": "0"
+                      "term": {
+                        "client_counties.id": "0"
                       }
                     }
                   ]
@@ -164,8 +164,8 @@
                       }
                     },
                     {
-                      "match": {
-                        "client_county.id": "{{_user.metadata.county_id}}"
+                      "term": {
+                        "client_counties.id": "{{_user.metadata.county_id}}"
                       }
                     }
                   ]
@@ -200,8 +200,8 @@
                       }
                     },
                     {
-                      "match": {
-                        "client_county.id": "0"
+                      "term": {
+                        "client_counties.id": "0"
                       }
                     }
                   ]


### PR DESCRIPTION
There is a new field in the people and people_summary indexes which contains multiple counties.
    "client_counties": {
      "properties": {
        "id": {
          "type": "text",
          "store": true
        },
        "description": {
          "type": "text",
          "store": true
        }
      }
    },

The x-pack policies were modified to use it instead of  "client_county".
