### PR TITLE
CALS-5645 Placement Home read/search: implement DocTool rule R - 05184 Placement Home Adoptions Only

### DIFF
--- a/config/shiro.ini
+++ b/config/shiro.ini
@@ -1,28 +1,16 @@
 [main]
 
 allowAllCredentialsMatcher = org.apache.shiro.authc.credential.AllowAllCredentialsMatcher
-globalPermissionResolver = gov.ca.cwds.security.permission.AbacPermissionResolver
-securityManager.authorizer.permissionResolver = $globalPermissionResolver
 
 # -------------
 # Perry Realm
 # -------------
-perryRealm = gov.ca.cwds.dora.security.intake.IntakeRealm
-perryRealm.keyStorePath=config/enc.jceks
-perryRealm.keyStoreAlias=test
-perryRealm.keyStorePassword=test
-perryRealm.keyStoreKeyPassword=test
-perryRealm.tokenIssuer=perry
-perryRealm.headlessToken=true
 
-#encryption
-
-perryRealm.useEncryption=true
-perryRealm.encKeyAlias=enc128
-perryRealm.encKeyPassword=test
-perryRealm.encryptionMethod=A128GCM
+perryRealm = gov.ca.cwds.dora.security.DoraRealm
+perryRealm.validationUri = http://perry:8080/perry/authn/validate
 
 perryRealm.credentialsMatcher = $allowAllCredentialsMatcher
+
 
 # ------------------------------
 # Perry Authenticating Filter

--- a/config/shiro_old.ini
+++ b/config/shiro_old.ini
@@ -1,16 +1,28 @@
 [main]
 
 allowAllCredentialsMatcher = org.apache.shiro.authc.credential.AllowAllCredentialsMatcher
+globalPermissionResolver = gov.ca.cwds.security.permission.AbacPermissionResolver
+securityManager.authorizer.permissionResolver = $globalPermissionResolver
 
 # -------------
 # Perry Realm
 # -------------
+perryRealm = gov.ca.cwds.dora.security.intake.IntakeRealm
+perryRealm.keyStorePath=config/enc.jceks
+perryRealm.keyStoreAlias=test
+perryRealm.keyStorePassword=test
+perryRealm.keyStoreKeyPassword=test
+perryRealm.tokenIssuer=perry
+perryRealm.headlessToken=true
 
-perryRealm = gov.ca.cwds.dora.security.DoraRealm
-perryRealm.validationUri = http://localhost:8080/perry/authn/validate
+#encryption
+
+perryRealm.useEncryption=true
+perryRealm.encKeyAlias=enc128
+perryRealm.encKeyPassword=test
+perryRealm.encryptionMethod=A128GCM
 
 perryRealm.credentialsMatcher = $allowAllCredentialsMatcher
-
 
 # ------------------------------
 # Perry Authenticating Filter

--- a/docker-dora/docker-compose.yml
+++ b/docker-dora/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '2.1'
+services:
+  perry:
+    image: cwds/perry:1.6.1_376-RC
+    hostname: perry
+    ports:
+      - ${PERRY_PORT}:8080
+      - ${PERRY_ADMIN_PORT}:8092
+    env_file: .env
+
+  cals_db2_data:
+    image: cwds/cals_db2_data
+    hostname: cals_db2_data
+    ports:
+      - ${DB_CMS_DB2_PORT}:${DB_CMS_DB2_PORT}
+    env_file: .env
+
+  postgresql_data:
+    image: cwds/postgresql_data
+    hostname: postgresql_data
+    ports:
+      - ${DB_POSTGRES_PORT}:${DB_POSTGRES_PORT}
+    env_file: .env
+
+  elasticsearch:
+    image: cwds/elasticsearch_xpack_data:${ELASTICSEARCH_XPACK_DATA_VERSION}
+    ports:
+      - 9200:9200
+      - 9300:9300
+    env_file: .env

--- a/docker-dora/env_template
+++ b/docker-dora/env_template
@@ -1,0 +1,26 @@
+#common
+PERRY_PORT=18080
+PERRY_ADMIN_PORT=18092
+SHOW_SWAGGER=true
+LOGIN_URL=http://localhost:${PERRY_PORT}/perry/authn/login
+LOGOUT_URL=http://localhost:${PERRY_PORT}/perry/authn/logout
+
+#perry
+DEV_MODE=true
+
+#cals-db2-data
+LOGLEVEL=INFO
+DB_CMS_DB2_HOST=cals_db2_data
+DB_CMS_DB2_PORT=50000
+DB_CMS_JDBC_URL=jdbc:db2://cals_db2_data:${DB_CMS_DB2_PORT}/DB0TDEV
+DB_CMS_RS_JDBC_URL=${DB_CMS_JDBC_URL}
+
+#postgress
+DB_POSTGRES_PORT=5432
+DB_FAS_JDBC_URL=jdbc:postgresql://postgresql_data:${DB_POSTGRES_PORT}/postgres_data
+DB_LIS_JDBC_URL=jdbc:postgresql://postgresql_data:${DB_POSTGRES_PORT}/postgres_data
+DB_NS_JDBC_URL=jdbc:postgresql://postgresql_data:${DB_POSTGRES_PORT}/postgres_data
+
+#elasticsearch
+ELASTICSEARCH_XPACK_DATA_VERSION=latest
+TOKEN_VALIDATION_URL = http://perry:8080/perry/authn/validate?token=

--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -175,6 +175,8 @@ task dockerPopulateTestPeople {
         String esFacilitiesUrl = "/facilities/facility/facility1"
         String facilityContent = readFile("$projectDir/test_data/facilities/facility.json")
         esExecute("PUT", esFacilitiesUrl, facilityContent)
+        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
+        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
 
         String esScreeningsUrl = "/screenings/screening/screening1"
         String screeningContent = readFile("$projectDir/test_data/screenings/screening.json")

--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -175,8 +175,10 @@ task dockerPopulateTestPeople {
         String esFacilitiesUrl = "/facilities/facility/facility1"
         String facilityContent = readFile("$projectDir/test_data/facilities/facility.json")
         esExecute("PUT", esFacilitiesUrl, facilityContent)
-        //String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
-        //esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
+
+        esFacilitiesUrl = "/facilities/facility/facility2"
+        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
+        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
 
         String esScreeningsUrl = "/screenings/screening/screening1"
         String screeningContent = readFile("$projectDir/test_data/screenings/screening.json")

--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -175,8 +175,8 @@ task dockerPopulateTestPeople {
         String esFacilitiesUrl = "/facilities/facility/facility1"
         String facilityContent = readFile("$projectDir/test_data/facilities/facility.json")
         esExecute("PUT", esFacilitiesUrl, facilityContent)
-        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
-        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
+//        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
+//        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
 
         String esScreeningsUrl = "/screenings/screening/screening1"
         String screeningContent = readFile("$projectDir/test_data/screenings/screening.json")

--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -175,8 +175,8 @@ task dockerPopulateTestPeople {
         String esFacilitiesUrl = "/facilities/facility/facility1"
         String facilityContent = readFile("$projectDir/test_data/facilities/facility.json")
         esExecute("PUT", esFacilitiesUrl, facilityContent)
-//        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
-//        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
+        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
+        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
 
         String esScreeningsUrl = "/screenings/screening/screening1"
         String screeningContent = readFile("$projectDir/test_data/screenings/screening.json")

--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -175,8 +175,8 @@ task dockerPopulateTestPeople {
         String esFacilitiesUrl = "/facilities/facility/facility1"
         String facilityContent = readFile("$projectDir/test_data/facilities/facility.json")
         esExecute("PUT", esFacilitiesUrl, facilityContent)
-        String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
-        esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
+        //String facilityAdoptionsContent = readFile("$projectDir/test_data/facilities/facility_adoptions.json")
+        //esExecute("PUT", esFacilitiesUrl, facilityAdoptionsContent)
 
         String esScreeningsUrl = "/screenings/screening/screening1"
         String screeningContent = readFile("$projectDir/test_data/screenings/screening.json")

--- a/docker-es-xpack/test_data/facilities/facility.json
+++ b/docker-es-xpack/test_data/facilities/facility.json
@@ -6,7 +6,6 @@
     "value": "Relative/NREFM Home"
   },
   "name": "Cool Dude",
-  "adoption_home_only_indicator": true,
   "licensee_name": "",
   "license_type": null,
   "assigned_worker": null,

--- a/docker-es-xpack/test_data/facilities/facility.json
+++ b/docker-es-xpack/test_data/facilities/facility.json
@@ -6,7 +6,7 @@
     "value": "Relative/NREFM Home"
   },
   "name": "Cool Dude",
-  "adoption_home_only_indicator": false,
+  "adoption_home_only_indicator": true,
   "licensee_name": "",
   "license_type": null,
   "assigned_worker": null,

--- a/docker-es-xpack/test_data/facilities/facility_adoptions.json
+++ b/docker-es-xpack/test_data/facilities/facility_adoptions.json
@@ -5,7 +5,7 @@
     "id": "793",
     "value": "Relative/NREFM Home"
   },
-  "name": "Cool Dude",
+  "name": "Some Name",
   "adoption_home_only_indicator": true,
   "licensee_name": "",
   "license_type": null,

--- a/docker-es-xpack/test_data/facilities/facility_adoptions.json
+++ b/docker-es-xpack/test_data/facilities/facility_adoptions.json
@@ -1,6 +1,6 @@
 {
   "href": null,
-  "id": "2b7SA3I04Y",
+  "id": "2b7SA3I04Z",
   "type": {
     "id": "793",
     "value": "Relative/NREFM Home"

--- a/docker-es-xpack/test_data/facilities/facility_adoptions.json
+++ b/docker-es-xpack/test_data/facilities/facility_adoptions.json
@@ -6,7 +6,7 @@
     "value": "Relative/NREFM Home"
   },
   "name": "Cool Dude",
-  "adoption_home_only_indicator": false,
+  "adoption_home_only_indicator": true,
   "licensee_name": "",
   "license_type": null,
   "assigned_worker": null,

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -245,7 +245,7 @@
     }
   },
   {
-    "action": "POST /_xpack/security/role/facilities_adoption_read",
+    "action": "POST /_xpack/security/role/facilities_read_adoptions",
     "content": {
       "cluster": [],
       "indices": [

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -224,6 +224,37 @@
           ],
           "privileges": [
             "read"
+          ],
+          "query": {
+            "template": {
+              "inline": {
+                "bool": {
+                  "must_not": [
+                    {
+                      "match": {
+                        "adoption_home_only_indicator": "Y"
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "action": "POST /_xpack/security/role/facilities_adoption_read",
+    "content": {
+      "cluster": [],
+      "indices": [
+        {
+          "names": [
+            "facilit*"
+          ],
+          "privileges": [
+            "read"
           ]
         }
       ]

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -232,7 +232,7 @@
                   "must_not": [
                     {
                       "match": {
-                        "adoption_home_only_indicator": "Y"
+                        "adoption_home_only_indicator": true
                       }
                     }
                   ]

--- a/dora-api/src/main/java/gov/ca/cwds/rest/resources/IndexQueryResource.java
+++ b/dora-api/src/main/java/gov/ca/cwds/rest/resources/IndexQueryResource.java
@@ -12,6 +12,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Example;
+import io.swagger.annotations.ExampleProperty;
 import javax.validation.Valid;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -69,14 +71,19 @@ public class IndexQueryResource {
   @ApiOperation(value = "Query given ElasticSearch index and type on given search terms", response = JSONObject.class)
   @Consumes(value = MediaType.APPLICATION_JSON)
   public Response searchIndex(
-      @PathParam("index") @ApiParam(required = true, name = "index", value = "The index of the search") String index,
-      @PathParam("type") @ApiParam(required = true, name = "type", value = "The document type") String type,
-      @Valid @ApiParam(required = true) Object req
+      @PathParam("index")
+      @ApiParam(required = true, name = "index", value = "The index of the search", example = "facilities")
+          String index,
+      @PathParam("type")
+      @ApiParam(required = true, name = "type", value = "The document type", example = "facility")
+          String type,
+      @Valid
+      @ApiParam(required = true, examples = @Example(@ExampleProperty(mediaType = MediaType.APPLICATION_JSON, value = "{\"query\":{\"match_all\":{}}}")))
+          Object req
   ) {
     long startTime = System.currentTimeMillis();
 
-    LOGGER.info("index: {}. type: {} query: {}", escapeCRLF(index),
-        escapeCRLF(type), escapeCRLF((null != req) ? req.toString() : null));
+    logRequestParams(index, type, req);
 
     IndexQueryRequest indexQueryRequest = new IndexQueryRequest(index, type, req);
     IndexQueryResponse indexQueryResponse = indexQueryService.handleRequest(indexQueryRequest);
@@ -86,5 +93,12 @@ public class IndexQueryResource {
     return indexQueryResponse == null ? null
         : Response.status(Response.Status.OK).entity(indexQueryResponse.getSearchResults())
             .build();
+  }
+
+  private void logRequestParams(String index, String type, Object req) {
+    String idxStr = escapeCRLF(index);
+    String typeStr = escapeCRLF(type);
+    String regStr = escapeCRLF((null != req) ? req.toString() : null);
+    LOGGER.info("index: {}. type: {} query: {}", idxStr, typeStr, regStr);
   }
 }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
@@ -60,19 +60,44 @@ public final class CwdsPrivileges {
     // JWT token will contain County Code, but Person documents in ES index and X-Pack roles use County ID
     cwdsPrivileges.countyId = countyCodeToCountyId(holder.getCountyCode());
     cwdsPrivileges.socialWorkerOnly = holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
-    cwdsPrivileges.countySensitive = holder.getPrivileges().contains(SENSITIVE_PERSONS) && (!holder
-        .isCountyIsStateOfCalifornia());
-    cwdsPrivileges.countySealed = holder.getPrivileges().contains(SEALED) && (!holder
-        .isCountyIsStateOfCalifornia());
-    cwdsPrivileges.stateSensitive = holder.getPrivileges().contains(SENSITIVE_PERSONS) && holder
-        .isCountyIsStateOfCalifornia();
-    cwdsPrivileges.stateSealed = holder.getPrivileges().contains(SEALED) && holder
-        .isCountyIsStateOfCalifornia();
-    cwdsPrivileges.facilitiesRead = holder.getPrivileges().contains(RESOURCE_MANAGEMENT)
-        || holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
-    cwdsPrivileges.facilitiesReadAdoptions =
-        cwdsPrivileges.facilitiesRead && holder.getPrivileges().contains(ADOPTIONS);
+    cwdsPrivileges.countySensitive = isCountySensitive(holder);
+    cwdsPrivileges.countySealed = isCountySealed(holder);
+    cwdsPrivileges.stateSensitive = isStateSensitive(holder);
+    cwdsPrivileges.stateSealed = isStateSealed(holder);
+    cwdsPrivileges.facilitiesRead = isFacilitiesRead(holder);
+    cwdsPrivileges.facilitiesReadAdoptions = isFacilitiesReadAdoptions(holder,
+        cwdsPrivileges.facilitiesRead);
     return cwdsPrivileges;
+  }
+
+  private static boolean isFacilitiesReadAdoptions(JsonTokenInfoHolder holder,
+      boolean isFacilitiesRead) {
+    return isFacilitiesRead && holder.getPrivileges().contains(ADOPTIONS);
+  }
+
+  private static boolean isFacilitiesRead(JsonTokenInfoHolder holder) {
+    return holder.getPrivileges().contains(RESOURCE_MANAGEMENT)
+        || holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
+  }
+
+  private static boolean isStateSealed(JsonTokenInfoHolder holder) {
+    return holder.getPrivileges().contains(SEALED) && holder
+        .isCountyIsStateOfCalifornia();
+  }
+
+  private static boolean isStateSensitive(JsonTokenInfoHolder holder) {
+    return holder.getPrivileges().contains(SENSITIVE_PERSONS) && holder
+        .isCountyIsStateOfCalifornia();
+  }
+
+  private static boolean isCountySealed(JsonTokenInfoHolder holder) {
+    return holder.getPrivileges().contains(SEALED) && (!holder
+        .isCountyIsStateOfCalifornia());
+  }
+
+  private static boolean isCountySensitive(JsonTokenInfoHolder holder) {
+    return holder.getPrivileges().contains(SENSITIVE_PERSONS) && (!holder
+        .isCountyIsStateOfCalifornia());
   }
 
   public boolean isCountySensitive() {

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
@@ -1,11 +1,14 @@
 package gov.ca.cwds.xpack.realm;
 
-import static gov.ca.cwds.xpack.realm.utils.Constants.*;
+import static gov.ca.cwds.xpack.realm.utils.Constants.ADOPTIONS;
+import static gov.ca.cwds.xpack.realm.utils.Constants.CWS_CASE_MANAGEMENT_SYSTEM;
+import static gov.ca.cwds.xpack.realm.utils.Constants.RESOURCE_MANAGEMENT;
+import static gov.ca.cwds.xpack.realm.utils.Constants.SEALED;
+import static gov.ca.cwds.xpack.realm.utils.Constants.SENSITIVE_PERSONS;
 import static gov.ca.cwds.xpack.realm.utils.PerryRealmUtils.countyCodeToCountyId;
 import static gov.ca.cwds.xpack.realm.utils.PerryRealmUtils.parsePerryTokenFromJSON;
 
 import gov.ca.cwds.xpack.realm.utils.JsonTokenInfoHolder;
-import java.io.IOException;
 
 /**
  * @author CWDS TPT-2
@@ -18,7 +21,8 @@ public final class CwdsPrivileges {
   private boolean stateSensitive = false;
   private boolean stateSealed = false;
   private String countyId = "";
-  private boolean facilitiesRead;
+  private boolean facilitiesRead = false;
+  private boolean facilitiesReadAdoptions = false;
 
   private CwdsPrivileges() {
     // no op
@@ -46,7 +50,7 @@ public final class CwdsPrivileges {
    * @throws IllegalArgumentException if can't parse the token
    */
   @SuppressWarnings("squid:S3776") // this method pretty straightforward
-  public static CwdsPrivileges fromJson(String json) throws IllegalArgumentException {
+  public static CwdsPrivileges fromJson(String json) {
     CwdsPrivileges cwdsPrivileges = new CwdsPrivileges();
 
     JsonTokenInfoHolder holder = parsePerryTokenFromJSON(json);
@@ -65,6 +69,8 @@ public final class CwdsPrivileges {
         .isCountyIsStateOfCalifornia();
     cwdsPrivileges.facilitiesRead = holder.getPrivileges().contains(RESOURCE_MANAGEMENT)
         || holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
+    cwdsPrivileges.facilitiesReadAdoptions =
+        cwdsPrivileges.facilitiesRead && holder.getPrivileges().contains(ADOPTIONS);
     return cwdsPrivileges;
   }
 
@@ -96,6 +102,10 @@ public final class CwdsPrivileges {
     return facilitiesRead;
   }
 
+  public boolean isFacilitiesReadAdoptions() {
+    return facilitiesReadAdoptions;
+  }
+
   @Override
   public String toString() {
     return "CwdsPrivileges{" +
@@ -105,6 +115,7 @@ public final class CwdsPrivileges {
         ", stateSensitive=" + stateSensitive +
         ", stateSealed=" + stateSealed +
         ", facilitiesRead=" + facilitiesRead +
+        ", facilitiesReadAdoptions=" + facilitiesReadAdoptions +
         ", countyId='" + countyId + '\'' +
         '}';
   }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
@@ -51,13 +51,14 @@ public final class CwdsPrivileges {
    */
   @SuppressWarnings("squid:S3776") // this method pretty straightforward
   public static CwdsPrivileges fromJson(String json) {
-    CwdsPrivileges cwdsPrivileges = new CwdsPrivileges();
-
     JsonTokenInfoHolder holder = parsePerryTokenFromJSON(json);
+    return buildPrivileges(holder);
+  }
 
+  private static CwdsPrivileges buildPrivileges(JsonTokenInfoHolder holder) {
+    CwdsPrivileges cwdsPrivileges = new CwdsPrivileges();
     // JWT token will contain County Code, but Person documents in ES index and X-Pack roles use County ID
     cwdsPrivileges.countyId = countyCodeToCountyId(holder.getCountyCode());
-
     cwdsPrivileges.socialWorkerOnly = holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
     cwdsPrivileges.countySensitive = holder.getPrivileges().contains(SENSITIVE_PERSONS) && (!holder
         .isCountyIsStateOfCalifornia());

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
@@ -144,14 +144,12 @@ public class PerryRealm extends Realm {
         logger.debug(ADDING_ROLE, PEOPLE_SEALED_NO_COUNTY);
       }
 
-      if(cwdsPrivileges.isFacilitiesRead()) {
-        rolesList.add(FACILITIES_READ);
-        logger.debug(ADDING_ROLE, FACILITIES_READ);
-      }
-      
       if (cwdsPrivileges.isFacilitiesReadAdoptions()){
         rolesList.add(FACILITIES_READ_ADOPTIONS);
         logger.debug(ADDING_ROLE, FACILITIES_READ_ADOPTIONS);
+      } else if (cwdsPrivileges.isFacilitiesRead()) {
+        rolesList.add(FACILITIES_READ);
+        logger.debug(ADDING_ROLE, FACILITIES_READ);
       }
 
       String[] roles = rolesList.toArray(new String[rolesList.size()]);

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
@@ -43,6 +43,7 @@ public class PerryRealm extends Realm {
   private static final String PEOPLE_SEALED = "people_sealed";
   private static final String PEOPLE_SEALED_NO_COUNTY = "people_sealed_no_county";
   private static final String FACILITIES_READ = "facilities_read";
+  private static final String FACILITIES_READ_ADOPTIONS = "facilities_read_adoptions";
 
   private static final String PEOPLE_SUMMARY_WORKER = "people_summary_worker";
   private static final String ADDING_ROLE = "adding {} role";
@@ -147,6 +148,11 @@ public class PerryRealm extends Realm {
         rolesList.add(FACILITIES_READ);
         logger.debug(ADDING_ROLE, FACILITIES_READ);
       }
+      
+      if (cwdsPrivileges.isFacilitiesReadAdoptions()){
+        rolesList.add(FACILITIES_READ_ADOPTIONS);
+        logger.debug(ADDING_ROLE, FACILITIES_READ_ADOPTIONS);
+      }
 
       String[] roles = rolesList.toArray(new String[rolesList.size()]);
       logger.info("roles: " + rolesList);
@@ -158,10 +164,10 @@ public class PerryRealm extends Realm {
       listener.onResponse(user);
 
     } catch (PerryTokenValidationException e) {
-      logger.warn("invalid Perry Token: " + e.getMessage());
+      logger.warn("invalid Perry Token: " + e.getMessage(), e);
       listener.onResponse(null);
     } catch (JsonProcessingException | IllegalArgumentException e) {
-      logger.warn("failed to parse Json Token: " + e.getMessage());
+      logger.warn("failed to parse Json Token: " + e.getMessage(), e);
       listener.onResponse(null);
     } catch (IOException e) {
       listener.onFailure(e);

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/Constants.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/Constants.java
@@ -3,18 +3,22 @@ package gov.ca.cwds.xpack.realm.utils;
 /**
  * @author CWDS TPT-2
  */
-public interface Constants {
+public class Constants {
 
   //fields
-  String COUNTY_CODE = "county_code";
-  String COUNTY_NAME = "county_name";
-  String PRIVILEGES = "privileges";
-
+  public static final String COUNTY_CODE = "county_code";
+  public static final String COUNTY_NAME = "county_name";
+  public static final String PRIVILEGES = "privileges";
   //privileges
-  String CWS_CASE_MANAGEMENT_SYSTEM = "CWS Case Management System";
-  String SENSITIVE_PERSONS = "Sensitive Persons";
-  String SEALED = "Sealed";
-  String RESOURCE_MANAGEMENT = "Resource Management";
+  public static final String CWS_CASE_MANAGEMENT_SYSTEM = "CWS Case Management System";
+  public static final String SENSITIVE_PERSONS = "Sensitive Persons";
+  public static final String SEALED = "Sealed";
+  public static final String RESOURCE_MANAGEMENT = "Resource Management";
+  public static final String ADOPTIONS = "Adoptions";
 
-  String STATE_OF_CALIFORNIA = "State of California";
+  public static final String STATE_OF_CALIFORNIA = "State of California";
+
+  private Constants() {
+  }
+
 }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
@@ -1,13 +1,22 @@
 package gov.ca.cwds.xpack.realm.utils;
 
+import static gov.ca.cwds.xpack.realm.utils.Constants.ADOPTIONS;
+import static gov.ca.cwds.xpack.realm.utils.Constants.COUNTY_CODE;
+import static gov.ca.cwds.xpack.realm.utils.Constants.COUNTY_NAME;
+import static gov.ca.cwds.xpack.realm.utils.Constants.CWS_CASE_MANAGEMENT_SYSTEM;
+import static gov.ca.cwds.xpack.realm.utils.Constants.PRIVILEGES;
+import static gov.ca.cwds.xpack.realm.utils.Constants.RESOURCE_MANAGEMENT;
+import static gov.ca.cwds.xpack.realm.utils.Constants.SEALED;
+import static gov.ca.cwds.xpack.realm.utils.Constants.SENSITIVE_PERSONS;
+import static gov.ca.cwds.xpack.realm.utils.Constants.STATE_OF_CALIFORNIA;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-
-import static gov.ca.cwds.xpack.realm.utils.Constants.*;
+import org.elasticsearch.index.mapper.ObjectMapper;
 
 /**
  * @author CWDS TPT-2
@@ -82,8 +91,7 @@ public final class PerryRealmUtils {
     countyCodeToCountyIdMap.put("99", "1126"); // State of California
   }
 
-  public static JsonTokenInfoHolder parsePerryTokenFromJSON(String json)
-      throws IllegalArgumentException {
+  public static JsonTokenInfoHolder parsePerryTokenFromJSON(String json) {
     if (null == json) {
       throw new IllegalArgumentException("JSON token is null");
     }
@@ -96,7 +104,6 @@ public final class PerryRealmUtils {
     List<String> privileges = new LinkedList<>();
 
     try (JsonParser parser = jsonFactory.createParser(json)) {
-
       while (parser.nextToken() != null) {
         String fieldName = parser.getCurrentName();
         if (COUNTY_CODE.equals(fieldName)) {
@@ -113,8 +120,10 @@ public final class PerryRealmUtils {
               privileges.add(SENSITIVE_PERSONS);
             } else if (SEALED.equalsIgnoreCase(privilege)) {
               privileges.add(SEALED);
-            } else if(RESOURCE_MANAGEMENT.equalsIgnoreCase(privilege)) {
+            } else if (RESOURCE_MANAGEMENT.equalsIgnoreCase(privilege)) {
               privileges.add(RESOURCE_MANAGEMENT);
+            } else if (ADOPTIONS.equalsIgnoreCase(privilege)) {
+              privileges.add(ADOPTIONS);
             }
           }
         } else if (COUNTY_NAME.equals(fieldName)) {

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.core.JsonToken;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import org.elasticsearch.index.mapper.ObjectMapper;
 
 /**
  * @author CWDS TPT-2

--- a/x-pack-perry-realm/src/test/java/gov/ca/cwds/xpack/realm/CwdsPrivilegesTest.java
+++ b/x-pack-perry-realm/src/test/java/gov/ca/cwds/xpack/realm/CwdsPrivilegesTest.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.xpack.realm;
 
 import static io.dropwizard.testing.FixtureHelpers.fixture;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import org.junit.Test;
@@ -13,24 +13,30 @@ public class CwdsPrivilegesTest {
 
   @Test
   public void testCwdsPrivileges() throws IOException {
-    assertCwdsPrivileges("fixtures/jwtToken-test1.json", false, false, false, false, false, false,"1086");
-    assertCwdsPrivileges("fixtures/jwtToken-test2.json", false,false, true, false, false, false,"1086");
-    assertCwdsPrivileges("fixtures/jwtToken-test3.json", false,true, false, false, false, false,"1086");
-    assertCwdsPrivileges("fixtures/jwtToken-test4.json", false,false, true, false, false, false,"1123");
-    assertCwdsPrivileges("fixtures/jwtToken-test5.json", true,true, false, false, false, true,"1123");
-    assertCwdsPrivileges("fixtures/jwtToken-test6.json", false,false, false, true, true, false,"1126");
+
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test1.json", false, false, false, false, false, false, false, "1086"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test2.json", false,false, true, false, false, false, false,"1086"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test3.json", false,true, false, false, false, false, false,"1086"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test4.json", false,false, true, false, false, false, false,"1123"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test5.json", true,true, false, false, false, true, false,"1123"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test6.json", false,false, false, true, true, false, false,"1126"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test7.json", false,false, false, true, true, true, true,"1126"));
   }
 
-  private void assertCwdsPrivileges(String jsonFile, boolean isSocialWorkerOnly, boolean isCountySealed,
-      boolean isCountySensitive, boolean isStateSealed, boolean isStateSensitive, boolean facilitiesRead, String countyId)
-      throws IOException {
+  private boolean isCwdsPrivilegesEqualsToJson(String jsonFile, boolean isSocialWorkerOnly, boolean isCountySealed,
+      boolean isCountySensitive, boolean isStateSealed, boolean isStateSensitive, boolean facilitiesRead, boolean facilitiesReadAdoptions, String countyId) {
     CwdsPrivileges cwdsPrivileges = CwdsPrivileges.fromJson(fixture(jsonFile));
-    assertEquals(isSocialWorkerOnly, cwdsPrivileges.isSocialWorkerOnly());
-    assertEquals(isCountySealed, cwdsPrivileges.isCountySealed());
-    assertEquals(isCountySensitive, cwdsPrivileges.isCountySensitive());
-    assertEquals(isStateSealed, cwdsPrivileges.isStateSealed());
-    assertEquals(isStateSensitive, cwdsPrivileges.isStateSensitive());
-    assertEquals(countyId, cwdsPrivileges.getCountyId());
-    assertEquals(facilitiesRead, cwdsPrivileges.isFacilitiesRead());
+    boolean result = true;
+
+    result = isSocialWorkerOnly == cwdsPrivileges.isSocialWorkerOnly();
+    result &= isCountySealed == cwdsPrivileges.isCountySealed();
+    result &= isCountySensitive == cwdsPrivileges.isCountySensitive();
+    result &= isStateSealed == cwdsPrivileges.isStateSealed();
+    result &= isStateSensitive == cwdsPrivileges.isStateSensitive();
+    result &= countyId.equals(cwdsPrivileges.getCountyId());
+    result &= facilitiesRead == cwdsPrivileges.isFacilitiesRead();
+    result &= facilitiesReadAdoptions == cwdsPrivileges.isFacilitiesReadAdoptions();
+
+    return result;
   }
 }

--- a/x-pack-perry-realm/src/test/resources/fixtures/jwtToken-test7.json
+++ b/x-pack-perry-realm/src/test/resources/fixtures/jwtToken-test7.json
@@ -1,0 +1,16 @@
+{
+  "user": "RACFID",
+  "staffId": "34",
+  "roles": ["Supervisor"],
+  "county_code": "99",
+  "county_name": "State of California",
+  "privileges": [
+    "Countywide Read/Write",
+    "Sealed",
+    "Statewide Read",
+    "Sensitive Persons",
+    "Resource Management",
+    "Adoptions"
+  ],
+  "government_entity_type" : "State of California"
+}


### PR DESCRIPTION
### JIRA Issue Link
- https://osi-cwds.atlassian.net/browse/CALS-5645

### Technical Description
Implementation of  DocTool rule R - 05184 
Rule text:
If the logged on user does not have Adoptions Privileges and if the Adoptions only indicator is set to 'Y', then the Placement Home is not visible to the logged on user else it is visible.

### Tests
- [x] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
Please indicate why tests were not added.

### Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
