### PR TITLE
COG-257: Filtering users by Admin county

### DIFF
--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -187,7 +187,7 @@ task dockerPopulateTestPeople {
         esExecute("PUT", esScreeningsUrl, screeningContent)
 
         // populate test users data
-        ["A", "B", "C", "D"].each {
+        ["A", "B", "C", "D", "E"].each {
             String esUrl = "/users/user/user_$it"
             String content = readFile("$projectDir/test_data/users/user_${it}.json")
             esExecute("PUT", esUrl, content)

--- a/docker-es-xpack/test_data/users/user_E.json
+++ b/docker-es-xpack/test_data/users/user_E.json
@@ -1,0 +1,19 @@
+{
+  "id": "128e120c-d643-44ac-ad9b-4a3fc767f04d",
+  "first_name": "Fritz",
+  "last_name": "Schmidt",
+  "county_name": "Yolo",
+  "start_date": "2017-12-12",
+  "office": "Yolo Central",
+  "phone_number": "0123456789",
+  "phone_extension_number": "0",
+  "email": "fritz.schmidt@osi.ca.gov",
+  "user_create_date": "2017-11-11",
+  "user_last_modified_date": "2018-06-06",
+  "enabled": true,
+  "status": "FORCE_CHANGE_PASSWORD",
+  "permissions": [
+    "Facility-search-rollout",
+    "Hotline-rollout"
+  ]
+}

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -273,9 +273,11 @@
             "read"
           ],
           "query": {
-            "inline": {
-              "match": {
-                "county_name": "Madera"
+            "template": {
+              "inline": {
+                "match": {
+                  "county_name": "Madera"
+                }
               }
             }
           }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -271,7 +271,16 @@
           ],
           "privileges": [
             "read"
-          ]
+          ],
+          "query": {
+            "template": {
+              "inline": {
+                "term": {
+                  "county_name": "{{_user.metadata.county_name}}"
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -278,7 +278,7 @@
                 "bool": {
                   "must": [
                     {
-                      "term": {
+                      "match": {
                         "county_name": "Madera"
                       }
                     }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -273,8 +273,10 @@
             "read"
           ],
           "query": {
-            "match": {
-              "county_name": "Madera"
+            "inline": {
+              "match": {
+                "county_name": "Madera"
+              }
             }
           }
         }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -272,7 +272,11 @@
           "privileges": [
             "read"
           ],
-          "query": "{ \"term\": { \"county_name\": \"Madera\" } }"
+          "query": {
+            "match": {
+              "county_name": "Madera"
+            }
+          }
         }
       ]
     }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -272,7 +272,7 @@
           "privileges": [
             "read"
           ],
-          "query": "{ \"match\": { \"county_name\": \"Madera\" } }"
+          "query": "{ \"term\": { \"county_name\": \"Madera\" } }"
         }
       ]
     }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -272,21 +272,7 @@
           "privileges": [
             "read"
           ],
-          "query": {
-            "template": {
-              "inline": {
-                "bool": {
-                  "must": [
-                    {
-                      "match": {
-                        "county_name": "Madera"
-                      }
-                    }
-                  ]
-                }
-              }
-            }
-          }
+          "query": "{ \"match\": { \"county_name\": \"Madera\" } }"
         }
       ]
     }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -279,7 +279,7 @@
                   "must": [
                     {
                       "term": {
-                        "county_name": "{{_user.metadata.county_name}}"
+                        "county_name": "Madera"
                       }
                     }
                   ]

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -276,7 +276,7 @@
             "template": {
               "inline": {
                 "match": {
-                  "county_name": "Madera"
+                  "county_name": "{{_user.metadata.county_name}}"
                 }
               }
             }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -275,8 +275,14 @@
           "query": {
             "template": {
               "inline": {
-                "term": {
-                  "county_name": "{{_user.metadata.county_name}}"
+                "bool": {
+                  "must": [
+                    {
+                      "term": {
+                        "county_name": "{{_user.metadata.county_name}}"
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/CwdsPrivileges.java
@@ -21,6 +21,7 @@ public final class CwdsPrivileges {
   private boolean stateSensitive = false;
   private boolean stateSealed = false;
   private String countyId = "";
+  private String countyName = "";
   private boolean facilitiesRead = false;
   private boolean facilitiesReadAdoptions = false;
 
@@ -59,6 +60,7 @@ public final class CwdsPrivileges {
     CwdsPrivileges cwdsPrivileges = new CwdsPrivileges();
     // JWT token will contain County Code, but Person documents in ES index and X-Pack roles use County ID
     cwdsPrivileges.countyId = countyCodeToCountyId(holder.getCountyCode());
+    cwdsPrivileges.countyName = holder.getCountyName();
     cwdsPrivileges.socialWorkerOnly = holder.getPrivileges().contains(CWS_CASE_MANAGEMENT_SYSTEM);
     cwdsPrivileges.countySensitive = isCountySensitive(holder);
     cwdsPrivileges.countySealed = isCountySealed(holder);
@@ -120,6 +122,10 @@ public final class CwdsPrivileges {
     return countyId;
   }
 
+  public String getCountyName() {
+    return countyName;
+  }
+
   public boolean isSocialWorkerOnly() {
     return socialWorkerOnly;
   }
@@ -143,6 +149,7 @@ public final class CwdsPrivileges {
         ", facilitiesRead=" + facilitiesRead +
         ", facilitiesReadAdoptions=" + facilitiesReadAdoptions +
         ", countyId='" + countyId + '\'' +
+        ", countyName='" + countyName + '\'' +
         '}';
   }
 }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/perry/PerryRealm.java
@@ -165,6 +165,7 @@ public class PerryRealm extends Realm {
 
       Map<String, Object> metadata = new HashMap<>();
       metadata.put("county_id", cwdsPrivileges.getCountyId());
+      metadata.put("county_name", cwdsPrivileges.getCountyName());
 
       User user = new User("perry", roles, "full name", "email@a.net", metadata, true);
       listener.onResponse(user);

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/JsonTokenInfoHolder.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/JsonTokenInfoHolder.java
@@ -11,6 +11,7 @@ public final class JsonTokenInfoHolder {
   private List<String> privileges;
   private Set<String> roles;
   private String countyCode;
+  private String countyName;
   private boolean countyIsStateOfCalifornia;
 
   public List<String> getPrivileges() {
@@ -37,6 +38,14 @@ public final class JsonTokenInfoHolder {
     this.countyCode = countyCode;
   }
 
+  public String getCountyName() {
+    return countyName;
+  }
+
+  public void setCountyName(String countyName) {
+    this.countyName = countyName;
+  }
+
   public boolean isCountyIsStateOfCalifornia() {
     return countyIsStateOfCalifornia;
   }
@@ -60,7 +69,8 @@ public final class JsonTokenInfoHolder {
     return countyIsStateOfCalifornia == holder.countyIsStateOfCalifornia
         && (privileges != null ? privileges.equals(holder.privileges) : holder.privileges == null)
         && (roles != null ? roles.equals(holder.roles) : holder.roles == null)
-        && (countyCode != null ? countyCode.equals(holder.countyCode) : holder.countyCode == null);
+        && (countyCode != null ? countyCode.equals(holder.countyCode) : holder.countyCode == null)
+        && (countyName != null ? countyName.equals(holder.countyName) : holder.countyName == null);
   }
 
   @Override
@@ -68,6 +78,7 @@ public final class JsonTokenInfoHolder {
     int result = privileges != null ? privileges.hashCode() : 0;
     result = 31 * result + (roles != null ? roles.hashCode() : 0);
     result = 31 * result + (countyCode != null ? countyCode.hashCode() : 0);
+    result = 31 * result + (countyName != null ? countyName.hashCode() : 0);
     result = 31 * result + (countyIsStateOfCalifornia ? 1 : 0);
     return result;
   }

--- a/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
+++ b/x-pack-perry-realm/src/main/java/gov/ca/cwds/xpack/realm/utils/PerryRealmUtils.java
@@ -143,8 +143,10 @@ public final class PerryRealmUtils {
           }
         } else if (COUNTY_NAME.equals(fieldName)) {
           parser.nextToken();
+          String countyName = parser.getValueAsString();
+          holder.setCountyName(countyName);
           holder.setCountyIsStateOfCalifornia(
-              checkThatCountyIsStateOfCalifornia(parser.getValueAsString()));
+              checkThatCountyIsStateOfCalifornia(countyName));
         }
       }
     } catch (Exception e) {

--- a/x-pack-perry-realm/src/test/java/gov/ca/cwds/xpack/realm/CwdsPrivilegesTest.java
+++ b/x-pack-perry-realm/src/test/java/gov/ca/cwds/xpack/realm/CwdsPrivilegesTest.java
@@ -17,20 +17,20 @@ import org.junit.Test;
 public class CwdsPrivilegesTest {
 
   @Test
-  public void testCwdsPrivileges() throws IOException {
+  public void testCwdsPrivileges() {
 
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test1.json", false, false, false, false, false, false, false, "1086"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test2.json", false,false, true, false, false, false, false,"1086"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test3.json", false,true, false, false, false, false, false,"1086"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test4.json", false,false, true, false, false, false, false,"1123"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test5.json", true,true, false, false, false, true, false,"1123"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test6.json", false,false, false, true, true, false, false,"1126"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test7.json", false,false, false, true, true, true, true,"1126"));
-    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test8.json", true,true, true, false, false, true, true,"1087", "CWS-admin"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test1.json", false, false, false, false, false, false, false, "1086", "Los Angeles"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test2.json", false,false, true, false, false, false, false,  "1086", "Los Angeles"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test3.json", false,true, false, false, false, false, false,"1086", "Los Angeles"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test4.json", false,false, true, false, false, false, false,"1123", "Ventura"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test5.json", true,true, false, false, false, true, false,"1123", "Ventura"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test6.json", false,false, false, true, true, false, false,"1126", "State of California"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test7.json", false,false, false, true, true, true, true,"1126", "State of California"));
+    assertTrue(isCwdsPrivilegesEqualsToJson("fixtures/jwtToken-test8.json", true,true, true, false, false, true, true,"1087", "Madera", "CWS-admin"));
   }
 
   private boolean isCwdsPrivilegesEqualsToJson(String jsonFile, boolean isSocialWorkerOnly, boolean isCountySealed,
-      boolean isCountySensitive, boolean isStateSealed, boolean isStateSensitive, boolean facilitiesRead, boolean facilitiesReadAdoptions, String countyId, String... expectedRoles) {
+      boolean isCountySensitive, boolean isStateSealed, boolean isStateSensitive, boolean facilitiesRead, boolean facilitiesReadAdoptions, String countyId, String countyName, String... expectedRoles) {
     JsonTokenInfoHolder holder = parsePerryTokenFromJSON(fixture(jsonFile));
     Set<String> roles =  holder.getRoles();
     CwdsPrivileges cwdsPrivileges = CwdsPrivileges.buildPrivileges(holder);
@@ -42,6 +42,7 @@ public class CwdsPrivilegesTest {
     result &= isStateSealed == cwdsPrivileges.isStateSealed();
     result &= isStateSensitive == cwdsPrivileges.isStateSensitive();
     result &= countyId.equals(cwdsPrivileges.getCountyId());
+    result &= countyName.equals(cwdsPrivileges.getCountyName());
     result &= facilitiesRead == cwdsPrivileges.isFacilitiesRead();
     result &= facilitiesReadAdoptions == cwdsPrivileges.isFacilitiesReadAdoptions();
     result &= roles.equals(new HashSet<>(Arrays.asList(expectedRoles)));


### PR DESCRIPTION
### JIRA Issue Link
- [COG-257: Authorization for elasticsearch querying for CAP Users](https://osi-cwds.atlassian.net/browse/COG-257)

### Technical Description
The authorized county admin can only see users from the same county he belongs to in the response to any search request.

### Tests
- [x] I have included unit tests 
Unit tests for Security token parsing was enhanced accordingly to changes in parsing logic.
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [] I have NOT included tests 

### Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask.
- [] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
