### PR TITLE
Perry port for invocation from other Docker container should be 8080

### DIFF
--- a/docker-dora/env_template
+++ b/docker-dora/env_template
@@ -10,16 +10,16 @@ ES_NODES=elasticsearch:9200
 PERRY_URL=http://localhost:${PERRY_PORT}/perry/authn/login
 XPACK_ENABLED=true
 SHOW_SWAGGER=true
-PERRY_VALIDATION_URL=http://perry:${PERRY_PORT}/perry/authn/validate
+PERRY_VALIDATION_URL=http://perry:8080/perry/authn/validate
 LOGIN_URL=http://localhost:${PERRY_PORT}/perry/authn/login
 LOGOUT_URL=http://localhost:${PERRY_PORT}/perry/authn/logout
-SWAGGER_TOKEN_URL=http://perry:${PERRY_PORT}/perry/authn/token
+SWAGGER_TOKEN_URL=http://perry:8080/perry/authn/token
 SWAGGER_JSON_URL=http://localhost:${DORA_PORT}/swagger.json
 SWAGGER_CALLBACK_URL=http://localhost:${DORA_PORT}/swagger
 
 
 #elasticsearch
-TOKEN_VALIDATION_URL=http://perry:${PERRY_PORT}/perry/authn/validate?token=
+TOKEN_VALIDATION_URL=http://perry:8080/perry/authn/validate?token=
 ELASTICSEARCH_XPACK_DATA_VERSION=latest
 
 


### PR DESCRIPTION

### Technical Description
Docker compose env template fix to allow PERRY_PORT to be set to the value different from 8080.

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 

### Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
