### PR TITLE
SNAP-594 - Make Dora configurable to skip health checks of Elasticsearch XPack Roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ For example `/dora/facilities/facility/_search` or `/dora/people/person/_search`
 
 Configuration options are available in the file config/dora.yml.
 
+Dora can be configured to run in `PROD` or `DEV` mode.
+The default mode is `PROD`, and it can be changed with the `DORA_MODE` environment variable accepting values `'PROD'` and `'DEV'`.
+When Dora is configured to run in `PROD` mode, it does not fire health checks of Elasticsearch XPack Roles.
+Any other mode will cause Dora to fire that health checks.
+
 ### Security Configuration
 
 #### Disabling Security

--- a/config/dora.yml
+++ b/config/dora.yml
@@ -22,6 +22,8 @@ swagger:
   callbackUrl: ${SWAGGER_CALLBACK_URL:-http://localhost:8090/swagger}
   tokenUrl: ${SWAGGER_TOKEN_URL:-http://localhost:8080/perry/authn/token}
 
+mode: ${DORA_MODE:-PROD}
+
 elasticsearch:
   nodes: ${ES_NODES:-dora.dev.cwds.io:9200,localhost:9200}
   user: ${XPACK_USER:-elastic}

--- a/config/dora_nosec.yml
+++ b/config/dora_nosec.yml
@@ -15,6 +15,8 @@ swagger:
   jsonUrl: ${SWAGGER_JSON_URL:-http://localhost:8080/swagger.json}
   callbackUrl: ${SWAGGER_CALLBACK_URL:-http://localhost:8080/swagger}
 
+mode: ${DORA_MODE:-PROD}
+
 elasticsearch:
   nodes: ${ES_NODES:-dora.dev.cwds.io:9200,localhost:9210}
   user: ${XPACK_USER:-elastic}

--- a/dora-api/src/main/java/gov/ca/cwds/dora/health/BasicDoraHealthCheck.java
+++ b/dora-api/src/main/java/gov/ca/cwds/dora/health/BasicDoraHealthCheck.java
@@ -3,6 +3,7 @@ package gov.ca.cwds.dora.health;
 import com.codahale.metrics.health.HealthCheck;
 import com.google.inject.Inject;
 import gov.ca.cwds.dora.DoraUtils;
+import gov.ca.cwds.rest.DoraConfiguration;
 import gov.ca.cwds.rest.ElasticsearchConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
@@ -16,27 +17,29 @@ public class BasicDoraHealthCheck extends HealthCheck {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(BasicDoraHealthCheck.class);
 
-  static final String HEALTHY_ES_CONFIG_MSG = "Dora is configured for Elasticsearch on nodes %s with X-pack %s.";
+  static final String HEALTHY_ES_CONFIG_MSG = "Dora is running in '%s' mode and configured for Elasticsearch on nodes %s with X-pack %s.";
   static final String UNHEALTHY_ES_CONFIG_MSG = "Dora is not properly configured for Elasticsearch.";
 
+  private DoraConfiguration config;
   private ElasticsearchConfiguration esConfig;
 
   /**
    * Constructor
    *
-   * @param esConfig instance of ElasticsearchConfiguration
+   * @param config instance of DoraConfiguration
    */
   @Inject
-  public BasicDoraHealthCheck(ElasticsearchConfiguration esConfig) {
-    this.esConfig = esConfig;
+  public BasicDoraHealthCheck(DoraConfiguration config) {
+    this.config = config;
+    this.esConfig = config.getElasticsearchConfiguration();
   }
 
   @Override
   protected Result check() throws Exception {
-
     if (elasticsearchConfigurationIsHealthy(esConfig.getNodes())) {
       String xPackStatus = esConfig.getXpack().isEnabled() ? "enabled" : "disabled";
-      String healthyMsg = String.format(HEALTHY_ES_CONFIG_MSG, esConfig.getNodes(), xPackStatus);
+      String healthyMsg = String.format(HEALTHY_ES_CONFIG_MSG, config.getMode(),
+          esConfig.getNodes(), xPackStatus);
       LOGGER.info(healthyMsg);
       return Result.healthy(healthyMsg);
     } else {

--- a/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchHealthCheck.java
+++ b/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchHealthCheck.java
@@ -3,7 +3,7 @@ package gov.ca.cwds.dora.health;
 import com.google.inject.Inject;
 import gov.ca.cwds.dora.DoraUtils;
 import gov.ca.cwds.managed.EsRestClientManager;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
+import gov.ca.cwds.rest.DoraConfiguration;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -24,11 +24,11 @@ public class ElasticsearchHealthCheck extends BasicDoraHealthCheck {
   /**
    * Constructor
    *
-   * @param esConfig instance of ElasticsearchConfiguration
+   * @param config instance of DoraConfiguration
    */
   @Inject
-  public ElasticsearchHealthCheck(ElasticsearchConfiguration esConfig) {
-    super(esConfig);
+  public ElasticsearchHealthCheck(DoraConfiguration config) {
+    super(config);
   }
 
   @Override

--- a/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchIndexHealthCheck.java
+++ b/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchIndexHealthCheck.java
@@ -1,5 +1,6 @@
 package gov.ca.cwds.dora.health;
 
+import gov.ca.cwds.rest.DoraConfiguration;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import com.google.inject.Inject;
 
 import gov.ca.cwds.dora.DoraUtils;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
 
 /**
  * @author CWDS TPT-2
@@ -32,11 +32,11 @@ public class ElasticsearchIndexHealthCheck extends ElasticsearchHealthCheck {
   /**
    * Constructor
    *
-   * @param esConfig instance of ElasticsearchConfiguration
+   * @param config instance of DoraConfiguration
    */
   @Inject
-  public ElasticsearchIndexHealthCheck(ElasticsearchConfiguration esConfig, String indexName) {
-    super(esConfig);
+  public ElasticsearchIndexHealthCheck(DoraConfiguration config, String indexName) {
+    super(config);
     this.indexName = indexName;
   }
 

--- a/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchPluginHealthCheck.java
+++ b/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchPluginHealthCheck.java
@@ -2,7 +2,7 @@ package gov.ca.cwds.dora.health;
 
 import com.google.inject.Inject;
 import gov.ca.cwds.dora.DoraUtils;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
+import gov.ca.cwds.rest.DoraConfiguration;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
@@ -28,11 +28,11 @@ public class ElasticsearchPluginHealthCheck extends ElasticsearchHealthCheck {
   /**
    * Constructor
    *
-   * @param esConfig instance of ElasticsearchConfiguration
+   * @param config instance of DoraConfiguration
    */
   @Inject
-  public ElasticsearchPluginHealthCheck(ElasticsearchConfiguration esConfig, String pluginName) {
-    super(esConfig);
+  public ElasticsearchPluginHealthCheck(DoraConfiguration config, String pluginName) {
+    super(config);
     this.pluginName = pluginName;
   }
 

--- a/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchRolesHealthCheck.java
+++ b/dora-api/src/main/java/gov/ca/cwds/dora/health/ElasticsearchRolesHealthCheck.java
@@ -1,7 +1,7 @@
 package gov.ca.cwds.dora.health;
 
 import com.google.inject.Inject;
-import gov.ca.cwds.rest.ElasticsearchConfiguration;
+import gov.ca.cwds.rest.DoraConfiguration;
 import org.elasticsearch.client.RestClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,11 +26,11 @@ public class ElasticsearchRolesHealthCheck extends ElasticsearchHealthCheck {
   /**
    * Constructor
    *
-   * @param esConfig instance of ElasticsearchConfiguration
+   * @param config instance of DoraConfiguration
    */
   @Inject
-  public ElasticsearchRolesHealthCheck(ElasticsearchConfiguration esConfig, String roleName) {
-    super(esConfig);
+  public ElasticsearchRolesHealthCheck(DoraConfiguration config, String roleName) {
+    super(config);
     this.roleName = roleName;
   }
 

--- a/dora-api/src/main/java/gov/ca/cwds/rest/DoraApplication.java
+++ b/dora-api/src/main/java/gov/ca/cwds/rest/DoraApplication.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.rest;
 
+import static gov.ca.cwds.rest.DoraConstants.PROD_MODE;
+
 import java.util.EnumSet;
 import java.util.Map;
 
@@ -50,10 +52,8 @@ public final class DoraApplication extends BaseApiApplication<DoraConfiguration>
   private static final String PHONETIC_SEARCH_PLUGIN_NAME = "analysis-phonetic";
   private static final String X_PACK_PLUGIN_NAME = "x-pack";
 
-  private static final String PEOPLE_INDEX = "people";
   private static final String FACILITIES_INDEX = "facilities";
   private static final String PEOPLE_SUMMARY_INDEX = "people-summary";
-  private static final String SCREENING_INDEX = "screenings";
 
   private static final String WORKER_ROLE = "worker";
   private static final String PEOPLE_WORKER_ROLE = "people_worker";
@@ -62,6 +62,8 @@ public final class DoraApplication extends BaseApiApplication<DoraConfiguration>
   private static final String PEOPLE_SEALED_ROLE = "people_sealed";
   private static final String PEOPLE_SEALED_NO_COUNTY_ROLE = "people_sealed_no_county";
   private static final String PEOPLE_SUMMARY_WORKER_ROLE = "people_summary_worker";
+
+  private static final String ROLE_HEALTHCHECK_PREFIX = "elasticsearch-role-";
 
   /**
    * Start the CWDS RESTful API application.
@@ -153,50 +155,41 @@ public final class DoraApplication extends BaseApiApplication<DoraConfiguration>
   private void registerHealthChecks(final DoraConfiguration configuration,
       final Environment environment) {
     environment.healthChecks().register("dora-es-config",
-        new BasicDoraHealthCheck(configuration.getElasticsearchConfiguration()));
+        new BasicDoraHealthCheck(configuration));
     environment.healthChecks().register("elasticsearch-status",
-        new ElasticsearchHealthCheck(configuration.getElasticsearchConfiguration()));
+        new ElasticsearchHealthCheck(configuration));
     environment.healthChecks().register("elasticsearch-plugin-" + PHONETIC_SEARCH_PLUGIN_NAME,
-        new ElasticsearchPluginHealthCheck(configuration.getElasticsearchConfiguration(),
-            PHONETIC_SEARCH_PLUGIN_NAME));
+        new ElasticsearchPluginHealthCheck(configuration, PHONETIC_SEARCH_PLUGIN_NAME));
     environment.healthChecks().register("elasticsearch-plugin-" + X_PACK_PLUGIN_NAME,
-        new ElasticsearchPluginHealthCheck(configuration.getElasticsearchConfiguration(),
-            X_PACK_PLUGIN_NAME));
+        new ElasticsearchPluginHealthCheck(configuration, X_PACK_PLUGIN_NAME));
     registerIndexHealthChecks(configuration, environment);
-    registerRolesHealthChecks(configuration, environment);
+    if (!PROD_MODE.equals(configuration.getMode())) {
+      registerRolesHealthChecks(configuration, environment);
+    }
   }
 
   private void registerRolesHealthChecks(DoraConfiguration configuration, Environment environment) {
-    environment.healthChecks().register("elasticsearch-role-" + WORKER_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            WORKER_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_WORKER_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_WORKER_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_SENSITIVE_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SENSITIVE_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_SENSITIVE_NO_COUNTY_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SENSITIVE_NO_COUNTY_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_SEALED_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SEALED_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_SEALED_NO_COUNTY_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SEALED_NO_COUNTY_ROLE));
-    environment.healthChecks().register("elasticsearch-role-" + PEOPLE_SUMMARY_WORKER_ROLE,
-        new ElasticsearchRolesHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SUMMARY_WORKER_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + WORKER_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, WORKER_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_WORKER_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_WORKER_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_SENSITIVE_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_SENSITIVE_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_SENSITIVE_NO_COUNTY_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_SENSITIVE_NO_COUNTY_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_SEALED_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_SEALED_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_SEALED_NO_COUNTY_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_SEALED_NO_COUNTY_ROLE));
+    environment.healthChecks().register(ROLE_HEALTHCHECK_PREFIX + PEOPLE_SUMMARY_WORKER_ROLE,
+        new ElasticsearchRolesHealthCheck(configuration, PEOPLE_SUMMARY_WORKER_ROLE));
   }
 
   private void registerIndexHealthChecks(DoraConfiguration configuration, Environment environment) {
     environment.healthChecks().register("elasticsearch-index-" + PEOPLE_SUMMARY_INDEX,
-        new ElasticsearchIndexHealthCheck(configuration.getElasticsearchConfiguration(),
-            PEOPLE_SUMMARY_INDEX));
+        new ElasticsearchIndexHealthCheck(configuration, PEOPLE_SUMMARY_INDEX));
     environment.healthChecks().register("elasticsearch-index-" + FACILITIES_INDEX,
-        new ElasticsearchIndexHealthCheck(configuration.getElasticsearchConfiguration(),
-            FACILITIES_INDEX));
+        new ElasticsearchIndexHealthCheck(configuration, FACILITIES_INDEX));
   }
 
   private void runHealthChecks(Environment environment) {

--- a/dora-api/src/main/java/gov/ca/cwds/rest/DoraConfiguration.java
+++ b/dora-api/src/main/java/gov/ca/cwds/rest/DoraConfiguration.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.rest;
 
+import static gov.ca.cwds.rest.DoraConstants.PROD_MODE;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.NotNull;
 
@@ -9,8 +11,19 @@ import javax.validation.constraints.NotNull;
 public class DoraConfiguration extends MinimalApiConfiguration {
 
 
+  @JsonProperty
+  private String mode;
+
   @NotNull
   private ElasticsearchConfiguration elasticsearchConfiguration;
+
+  public String getMode() {
+    return mode == null ? PROD_MODE : mode;
+  }
+
+  public void setMode(String mode) {
+    this.mode = mode;
+  }
 
   @JsonProperty(value = "elasticsearch")
   public ElasticsearchConfiguration getElasticsearchConfiguration() {

--- a/dora-api/src/main/java/gov/ca/cwds/rest/DoraConstants.java
+++ b/dora-api/src/main/java/gov/ca/cwds/rest/DoraConstants.java
@@ -10,4 +10,8 @@ public interface DoraConstants {
     String SYSTEM_INFORMATION = "system-information";
 
     String RESOURCE_ELASTICSEARCH_INDEX_QUERY = "dora";
+
+    String PROD_MODE = "PROD";
+
+    String DEV_MODE = "DEV";
 }

--- a/dora-api/src/test/java/gov/ca/cwds/rest/BaseDoraApplicationTest.java
+++ b/dora-api/src/test/java/gov/ca/cwds/rest/BaseDoraApplicationTest.java
@@ -1,5 +1,7 @@
 package gov.ca.cwds.rest;
 
+import static gov.ca.cwds.rest.DoraConstants.PROD_MODE;
+
 import gov.ca.cwds.rest.ElasticsearchConfiguration.XpackConfiguration;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -39,8 +41,15 @@ public abstract class BaseDoraApplicationTest {
   @Rule
   public RestClientTestRule clientTestRule = new RestClientTestRule(appRule);
 
-  public static ElasticsearchConfiguration esConfig(String nodes, boolean xPackEnabled,
-      String user, String password) {
+  public static DoraConfiguration config(String mode, ElasticsearchConfiguration esConfig) {
+    DoraConfiguration config = new DoraConfiguration();
+    config.setMode(mode);
+    config.setElasticsearchConfiguration(esConfig);
+    return config;
+  }
+
+  public static ElasticsearchConfiguration esConfig(String nodes, boolean xPackEnabled, String user,
+      String password) {
     XpackConfiguration xpackConfig = new XpackConfiguration();
     xpackConfig.setEnabled(xPackEnabled);
 
@@ -51,5 +60,10 @@ public abstract class BaseDoraApplicationTest {
     esConfig.setXpack(xpackConfig);
 
     return esConfig;
+  }
+
+  public static DoraConfiguration config(String nodes, boolean xPackEnabled, String user,
+      String password) {
+    return config(PROD_MODE, esConfig(nodes, xPackEnabled, user, password));
   }
 }

--- a/dora-api/src/test/resources/config/test-dora.yml
+++ b/dora-api/src/test/resources/config/test-dora.yml
@@ -13,6 +13,8 @@ swagger:
   loginUrl: ${PERRY_URL:-http://localhost:8090/authn/login}
   showSwagger: ${SHOW_SWAGGER:-false}
 
+mode: ${DORA_MODE:-DEV}
+
 elasticsearch:
   nodes: ${ES_NODES:-dora.dev.cwds.io:9200}
   user: ${XPACK_USER:-elastic}


### PR DESCRIPTION
### JIRA Issue Link
- [SNAP-594: Make Dora configurable to skip health checks of Elasticsearch XPack Roles](https://osi-cwds.atlassian.net/browse/SNAP-594)

### Technical Description
We need a way to configure Dora to skip health checks of Elasticsearch XPack Roles, because security configuration on higher environments prevents Dora accessing the /_xpack/security/role endpoint.

### Tests
- [x] I have included unit tests 

### Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
