### PR TITLE
COG-935 Office admin should not see CALS-external-user and CALS-admin roles in a list view

### DIFF
--- a/docker-es-xpack/build.gradle
+++ b/docker-es-xpack/build.gradle
@@ -187,7 +187,8 @@ task dockerPopulateTestPeople {
         esExecute("PUT", esScreeningsUrl, screeningContent)
 
         // populate test users data
-        ["A", "B", "C", "D", "E", "F", "G", "other_office_ca", "other_office_sa"].each {
+        ["A", "B", "C", "D", "E", "F", "G", "other_office_ca", "other_office_sa",
+         "cals_worker", "cals_admin"].each {
             String esUrl = "/users/user/user_$it"
             String content = readFile("$projectDir/test_data/users/user_${it}.json")
             esExecute("PUT", esUrl, content)

--- a/docker-es-xpack/test_data/users/user_cals_admin.json
+++ b/docker-es-xpack/test_data/users/user_cals_admin.json
@@ -1,0 +1,22 @@
+{
+  "id": "15055bbc-60da-4e1c-bf62-5dbcae5902e1",
+  "email": "asd@lkjsfv.fg",
+  "first_name": "Michael",
+  "last_name": "Burns",
+  "county_name": "Madera",
+  "racfid": "BURNSM",
+  "start_date": "2017-05-20",
+  "office_id": "NpuJq9k0Wz",
+  "phone_number": "5599994321",
+  "user_create_date": "2018-09-01",
+  "user_last_modified_date": "2018-10-25",
+  "enabled": true,
+  "status": "CONFIRMED",
+  "permissions": [
+    "Snapshot-rollout"
+  ],
+  "roles": [
+    "CALS-admin"
+  ]
+}
+

--- a/docker-es-xpack/test_data/users/user_cals_worker.json
+++ b/docker-es-xpack/test_data/users/user_cals_worker.json
@@ -1,0 +1,19 @@
+{
+  "id": "0136e80c-ab89-4347-b02f-3ac19a24cf2a",
+  "email": "asdfasd@vocmc.ov",
+  "first_name": "Gina",
+  "last_name": "Blakemore",
+  "county_name": "Madera",
+  "office_id": "NpuJq9k0Wz",
+  "user_create_date": "2018-08-27",
+  "user_last_modified_date": "2018-08-27",
+  "enabled": true,
+  "status": "CONFIRMED",
+  "permissions": [
+    "Hotline-rollout"
+  ],
+  "roles": [
+    "CALS-external-worker"
+  ]
+}
+

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -307,6 +307,13 @@
                       "match": {
                         "county_name.keyword": "{{_user.metadata.county_name}}"
                       }
+                    },
+                    {
+                      "bool": {
+                        "must_not": [
+                          { "match_phrase": { "roles": "CALS-external-worker" } }
+                        ]
+                      }
                     }
                   ]
                 }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -295,13 +295,20 @@
             "users"
           ],
           "privileges": [
-            "read", "write"
+            "read",
+            "write"
           ],
           "query": {
             "template": {
               "inline": {
-                "match": {
-                  "county_name.keyword": "{{_user.metadata.county_name}}"
+                "bool": {
+                  "must": [
+                    {
+                      "match": {
+                        "county_name.keyword": "{{_user.metadata.county_name}}"
+                      }
+                    }
+                  ]
                 }
               }
             }

--- a/docker-es-xpack/xpack_policies.json
+++ b/docker-es-xpack/xpack_policies.json
@@ -310,9 +310,20 @@
                     },
                     {
                       "bool": {
-                        "must_not": [
-                          { "match_phrase": { "roles": "CALS-external-worker" } }
-                        ]
+                        "must_not": {
+                          "match_phrase": {
+                            "roles": "CALS-external-worker"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "bool": {
+                        "must_not": {
+                          "match_phrase": {
+                            "roles": "CALS-admin"
+                          }
+                        }
                       }
                     }
                   ]


### PR DESCRIPTION
### JIRA Issue Link
- [COG-935: Office admin should not see CALS-external-user and CALS-admin roles in a list view](https://osi-cwds.atlassian.net/browse/COG-935)

### Technical Description
Office admin should not be able to view profile of CALS-admin or CALS-external-worker role user in the user list page

### Tests
- [ ] I have included unit tests 
- [ ] I have included integration tests 
- [ ] I have included performance tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
Tested manually

### Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
